### PR TITLE
Add basic chat agent

### DIFF
--- a/src/agents/basicSupportAgent.ts
+++ b/src/agents/basicSupportAgent.ts
@@ -1,0 +1,30 @@
+import { initializeAgentExecutorWithOptions } from "langchain/agents";
+import { BufferMemory } from "langchain/memory";
+import searchProceduresTool from "../tools/searchProcedures";
+import getProcedureDetailsTool from "../tools/getProcedureDetails";
+import { openaiConfig } from "../config/openai";
+
+export class BasicSupportAgent {
+  private executor: any;
+  private memory = new BufferMemory({
+    memoryKey: "chat_history",
+    returnMessages: true,
+  });
+
+  private async init() {
+    if (!this.executor) {
+      const tools = [searchProceduresTool, getProcedureDetailsTool];
+      this.executor = await initializeAgentExecutorWithOptions(tools, openaiConfig.getLLM(), {
+        agentType: "openai-functions",
+        memory: this.memory,
+        verbose: true,
+      });
+    }
+  }
+
+  public async processMessage(message: string) {
+    await this.init();
+    const result = await this.executor.call({ input: message });
+    return result.output as string;
+  }
+}

--- a/src/config/database.ts
+++ b/src/config/database.ts
@@ -1,0 +1,13 @@
+import { Pool } from 'pg';
+import * as dotenv from 'dotenv';
+
+dotenv.config();
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+});
+
+export const db = {
+  query: (text: string, params?: any[]) => pool.query(text, params),
+  getPool: () => pool,
+};

--- a/src/config/openai.ts
+++ b/src/config/openai.ts
@@ -1,0 +1,14 @@
+import { ChatOpenAI } from "@langchain/openai";
+import * as dotenv from 'dotenv';
+
+dotenv.config();
+
+export const openaiConfig = {
+  getLLM() {
+    return new ChatOpenAI({
+      apiKey: process.env.OPENAI_API_KEY,
+      modelName: process.env.OPENAI_MODEL || 'gpt-3.5-turbo',
+      temperature: 0.2,
+    });
+  },
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,13 @@ import express from 'express';
 import bodyParser from 'body-parser';
 import { handleIncomingData } from './utils/handleIncomingData';
 import { startPolling } from './pooling';
+import chatRouter from './routes/chat';
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 
 app.use(bodyParser.json({ limit: '50mb' }));
+app.use('/chat', chatRouter);
 
 let webhookReceived = false;
 

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -1,0 +1,22 @@
+import { Router } from 'express';
+import { BasicSupportAgent } from '../agents/basicSupportAgent';
+
+const router = Router();
+const agent = new BasicSupportAgent();
+
+router.post('/', async (req, res) => {
+  const { message } = req.body;
+  if (!message) {
+    res.status(400).json({ error: 'Mensagem obrigatória' });
+    return;
+  }
+  try {
+    const reply = await agent.processMessage(message);
+    res.json({ message: reply });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Erro ao processar mensagem' });
+  }
+});
+
+export default router;

--- a/src/tools/getProcedureDetails.ts
+++ b/src/tools/getProcedureDetails.ts
@@ -1,0 +1,21 @@
+import { DynamicStructuredTool } from "@langchain/core/tools";
+import { z } from "zod";
+import { db } from "../config/database";
+
+const getProcedureDetailsTool = new DynamicStructuredTool({
+  name: "obter_detalhes",
+  description: "Obtém detalhes completos de um procedimento pelo ID",
+  schema: z.object({
+    procedimento_id: z.number().describe("ID do procedimento"),
+  }),
+  func: async ({ procedimento_id }: { procedimento_id: number }) => {
+    const { rows } = await db.query(
+      "SELECT id, titulo, descricao_problema, solucao_completa FROM procedimentos WHERE id = $1",
+      [procedimento_id]
+    );
+    if (rows.length === 0) return "Procedimento não encontrado";
+    return JSON.stringify(rows[0]);
+  },
+});
+
+export default getProcedureDetailsTool;

--- a/src/tools/searchProcedures.ts
+++ b/src/tools/searchProcedures.ts
@@ -1,0 +1,29 @@
+import { DynamicStructuredTool } from "@langchain/core/tools";
+import { z } from "zod";
+import { db } from "../config/database";
+import { getEmbedding, embeddingParaPostgres } from "../services/embeddingService";
+
+const searchProceduresTool = new DynamicStructuredTool({
+  name: "buscar_procedimentos",
+  description: "Busca procedimentos semelhantes ao problema informado",
+  schema: z.object({
+    problema: z.string().describe("Descrição do problema"),
+    limite: z.number().default(3).describe("Número máximo de resultados"),
+  }),
+  func: async ({ problema, limite }: { problema: string; limite: number }) => {
+    const { embedding } = await getEmbedding(problema);
+    const embeddingStr = embeddingParaPostgres(embedding);
+    const query = `
+      SELECT id, titulo, descricao_problema,
+             1 - (embedding <=> $1::vector) AS score
+      FROM procedimentos
+      ORDER BY embedding <-> $1::vector
+      LIMIT $2
+    `;
+    const { rows } = await db.query(query, [embeddingStr, limite]);
+    if (rows.length === 0) return "Nenhum procedimento encontrado";
+    return JSON.stringify(rows);
+  },
+});
+
+export default searchProceduresTool;


### PR DESCRIPTION
## Summary
- add support agent using LangChain
- create Postgres and OpenAI configs
- expose `/chat` route
- define tools in separate files

## Testing
- `npm run build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870952e7cd48325b0fb2539c3fe065a